### PR TITLE
Remove obsolete AZP containers.

### DIFF
--- a/image/templates/Ubuntu-18.04-Minimal-30GB.json
+++ b/image/templates/Ubuntu-18.04-Minimal-30GB.json
@@ -25,10 +25,6 @@
             },
             {
                 "inline": [
-                    "sudo docker pull quay.io/ansible/azure-pipelines-test-container:1.6.0",
-                    "sudo docker pull quay.io/ansible/azure-pipelines-test-container:1.7.0",
-                    "sudo docker pull quay.io/ansible/azure-pipelines-test-container:1.7.1",
-                    "sudo docker pull quay.io/ansible/azure-pipelines-test-container:1.8.0",
                     "sudo docker pull quay.io/ansible/azure-pipelines-test-container:1.9.0",
                     "sudo docker pull quay.io/ansible/azure-pipelines-test-container:3.0.0"
                 ],

--- a/lookup_plugins/annotated_pull_commands.py
+++ b/lookup_plugins/annotated_pull_commands.py
@@ -49,10 +49,6 @@ def get_container_names(branch, git_cache_path):  # type: (str, str) -> t.List[s
 def get_docker_pull_commands(branches, git_repo_path):  # type: (t.List[str], str) -> t.List[str]
     """Return a list of docker pull commands for container images used in the given branches."""
     images = {
-        'quay.io/ansible/azure-pipelines-test-container:1.6.0',
-        'quay.io/ansible/azure-pipelines-test-container:1.7.0',
-        'quay.io/ansible/azure-pipelines-test-container:1.7.1',
-        'quay.io/ansible/azure-pipelines-test-container:1.8.0',
         'quay.io/ansible/azure-pipelines-test-container:1.9.0',
         'quay.io/ansible/azure-pipelines-test-container:3.0.0',
     }


### PR DESCRIPTION
The 3.0.0 container is current. The 1.9.0 version is still in use by stable-2.9.