### PR TITLE
Bump azure-pipelines-test-container to v4.0.1

### DIFF
--- a/image/templates/Ubuntu-22.04-Minimal-30GB.json
+++ b/image/templates/Ubuntu-22.04-Minimal-30GB.json
@@ -44,6 +44,8 @@
                 "inline": [
                     "echo Pulling quay.io/ansible/azure-pipelines-test-container:3.0.0 ...",
                     "sudo docker pull quay.io/ansible/azure-pipelines-test-container:3.0.0",
+                    "echo Pulling quay.io/ansible/azure-pipelines-test-container:4.0.1 ...",
+                    "sudo docker pull quay.io/ansible/azure-pipelines-test-container:4.0.1",
                     "echo All images have been pulled"
                 ],
                 "name": "Pull Docker Images",

--- a/lookup_plugins/annotated_pull_commands.py
+++ b/lookup_plugins/annotated_pull_commands.py
@@ -50,6 +50,7 @@ def get_docker_pull_commands(branches, git_repo_path):  # type: (t.List[str], st
     """Return a list of docker pull commands for container images used in the given branches."""
     images = {
         'quay.io/ansible/azure-pipelines-test-container:3.0.0',
+        'quay.io/ansible/azure-pipelines-test-container:4.0.1',
     }
 
     image_comments = {image: set() for image in images}


### PR DESCRIPTION
This patch updates the test container used in CI to the new v4 that defaults to using Python 3.10 and is based on Ubuntu 22.04 Jammy[[1]].

[1]: https://github.com/ansible/azure-pipelines-test-container/pull/17

Refs:
* https://github.com/ansible/ansible/issues/80424
* https://github.com/ansible/azure-pipelines-test-container/pull/17
* https://github.com/ansible/ansible/pull/80916