### PR TITLE
Run post-upgrade reboots in a controlled manner

### DIFF
--- a/image/template.yml
+++ b/image/template.yml
@@ -12,10 +12,13 @@ properties:
   buildTimeoutInMinutes: "{{ build_timeout_minutes }}"
   customize:
     - inline:
-        - echo Removing unattended-upgrades ...
-        - sudo apt-get purge unattended-upgrades -y
+        - export DEBIAN_FRONTEND=noninteractive
+        - export NEEDRESTART_SUSPEND=1
+        - export NEEDRESTART_MODE=l
         - echo Updating apt database ...
         - sudo apt-get update -y
+        - echo Removing needrestart and unattended-upgrades ...
+        - sudo apt-get purge needrestart unattended-upgrades -y
         - echo Upgrading installed packages ...
         - sudo apt-get upgrade -y
         - echo Removing unused packages ...
@@ -26,6 +29,13 @@ properties:
         - sudo rm -rf /var/log/unattended-upgrades
         - echo Package installation complete
       name: Install Packages
+      type: Shell
+    - expect_disconnect: true
+      inline:
+        - echo Pre-reboot
+        - sudo systemctl reboot
+      pause_after: 10s
+      name: Rebooting the VM
       type: Shell
     - inline:
         - echo Creating cgroup-v1 service ...

--- a/image/templates/Ubuntu-22.04-Minimal-30GB.json
+++ b/image/templates/Ubuntu-22.04-Minimal-30GB.json
@@ -12,10 +12,13 @@
         "customize": [
             {
                 "inline": [
-                    "echo Removing unattended-upgrades ...",
-                    "sudo apt-get purge unattended-upgrades -y",
+                    "export DEBIAN_FRONTEND=noninteractive",
+                    "export NEEDRESTART_SUSPEND=1",
+                    "export NEEDRESTART_MODE=l",
                     "echo Updating apt database ...",
                     "sudo apt-get update -y",
+                    "echo Removing needrestart and unattended-upgrades ...",
+                    "sudo apt-get purge needrestart unattended-upgrades -y",
                     "echo Upgrading installed packages ...",
                     "sudo apt-get upgrade -y",
                     "echo Removing unused packages ...",
@@ -27,6 +30,16 @@
                     "echo Package installation complete"
                 ],
                 "name": "Install Packages",
+                "type": "Shell"
+            },
+            {
+                "expect_disconnect": true,
+                "inline": [
+                    "echo Pre-reboot",
+                    "sudo systemctl reboot"
+                ],
+                "name": "Rebooting the VM",
+                "pause_after": "10s",
                 "type": "Shell"
             },
             {


### PR DESCRIPTION
This patch removes the `needrestart` package during the VM image generation to stop it from causing a reboot at inconvenient time. It then adds a separate step for rebooting the VM using `systemctl` making Packer wait for the reboot to complete before proceeding.